### PR TITLE
Allow override configurations to contain null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Spectator is a Windows Service for taking measurements from Performance Counters
 
 Features:
 * Installs as a Windows service (via Topshelf)
-* Supports reading metric values from Performance Counters
-* Supports reading values from WMI (via ManagedObjectSearcher queries)
+* Supports reading metric values from Performance Counters or from from WMI (via ManagedObjectSearcher queries)
 * Pushes metrics via UDP to any Statsd-compatible server
 * Customisable metric names via templates
-* Exclude Performance Counter instances from being measured, using exclusion patterns
-* JSON configuration via local file or stored in a Consul key/value store
+* Exclude particular Performance Counter instances from being measured, using exclusion and/or inclusion patterns
+* JSON configuration via local file (`base-spectator-config.json`)
+* Dynamic configuration via override configurations kept in a Consul key/value store
+  * Local caching of remote override configuration in case of temporary Consul outage
 
 Quick Start
 -----------
@@ -42,8 +43,8 @@ spectator.exe start
 ```
 
 
-Configuration Example
----------------------
+Base Configuration Example
+--------------------------
 
 ```
 {

--- a/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithBasicOverridesTests.cs
+++ b/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithBasicOverridesTests.cs
@@ -2,19 +2,20 @@
 using NUnit.Framework;
 using spectator.Configuration;
 
-namespace spectator.Tests.Configuration
+namespace spectator.Tests.Configuration.CombinedSpectatorConfigurationTests
 {
     [TestFixture]
-    public class CombinedSpectatorConfigurationTests
+    public class WithBasicOverridesTests
     {
-        private ISpectatorConfiguration _overrideConfig;
+        private ISpectatorOverrideConfiguration _overrideConfig;
+        private ISpectatorOverrideConfiguration _emptyOverrideConfig;
         private ISpectatorConfiguration _baseConfig;
         private CombinedSpectatorConfiguration _combinedConfig;
 
         [SetUp]
         public void SetUp()
         {
-            _baseConfig = JsonSpectatorConfiguration.LoadFromString(@"{
+            _baseConfig = JsonSpectatorConfiguration.LoadConfigFromString(@"{
                       ""statsdHost"": ""basehost"",
                       ""statsdPort"": 8125,
                       ""metricPrefix"": ""base.prefix"",
@@ -35,7 +36,7 @@ namespace spectator.Tests.Configuration
                       ]
                     }");
 
-            _overrideConfig = JsonSpectatorConfiguration.LoadFromString(@"{
+            _overrideConfig = JsonSpectatorConfiguration.LoadConfigFromString(@"{
                       ""statsdHost"": ""overridehost"",
                       ""statsdPort"": 8126,
                       ""metricPrefix"": ""override.prefix"",

--- a/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithBasicOverridesTests.cs
+++ b/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithBasicOverridesTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 using spectator.Configuration;
+using spectator.Configuration.Overrides;
 
 namespace spectator.Tests.Configuration.CombinedSpectatorConfigurationTests
 {
@@ -8,7 +9,6 @@ namespace spectator.Tests.Configuration.CombinedSpectatorConfigurationTests
     public class WithBasicOverridesTests
     {
         private ISpectatorOverrideConfiguration _overrideConfig;
-        private ISpectatorOverrideConfiguration _emptyOverrideConfig;
         private ISpectatorConfiguration _baseConfig;
         private CombinedSpectatorConfiguration _combinedConfig;
 

--- a/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithEmptyOverridesTests.cs
+++ b/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithEmptyOverridesTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 using spectator.Configuration;
+using spectator.Configuration.Overrides;
 
 namespace spectator.Tests.Configuration.CombinedSpectatorConfigurationTests
 {

--- a/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithEmptyOverridesTests.cs
+++ b/spectator.Tests/Configuration/CombinedSpectatorConfigurationTests/WithEmptyOverridesTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using spectator.Configuration;
+
+namespace spectator.Tests.Configuration.CombinedSpectatorConfigurationTests
+{
+    [TestFixture]
+    public class WithEmptyOverridesTests
+    {
+        private ISpectatorOverrideConfiguration _overrideConfig;
+        private ISpectatorConfiguration _baseConfig;
+        private CombinedSpectatorConfiguration _combinedConfig;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _baseConfig = JsonSpectatorConfiguration.LoadConfigFromString(@"{
+                      ""statsdHost"": ""basehost"",
+                      ""statsdPort"": 8125,
+                      ""metricPrefix"": ""base.prefix"",
+                      ""interval"":  ""00:00:01"",
+                      ""metrics"": [
+                        {
+                          ""source"": ""performanceCounter"",
+                          ""path"": ""\\Processor(_Total)\\Interrupts/sec"",
+                          ""type"": ""gauge"",
+                          ""template"": ""base.performance.counter""
+                        },
+                        {
+                          ""source"": ""performanceCounter"",
+                          ""path"": ""\\Processor(_Total)\\Interrupts/sec"",
+                          ""type"": ""gauge"",
+                          ""template"": ""overriden.performance.counter""
+                        }
+                      ]
+                    }");
+
+            _overrideConfig = JsonSpectatorConfiguration.LoadConfigFromString(@"{
+                      ""metrics"": [
+                      ]
+                    }");
+
+            _combinedConfig = new CombinedSpectatorConfiguration(_baseConfig, _overrideConfig);
+        }
+
+        [Test]
+        public void the_base_statsd_host_should_be_used()
+        {
+            Assert.That(_combinedConfig.StatsdHost, Is.EqualTo(_baseConfig.StatsdHost));
+        }
+
+        [Test]
+        public void the_base_statsd_port_should_be_used()
+        {
+            Assert.That(_combinedConfig.StatsdPort, Is.EqualTo(_baseConfig.StatsdPort));
+        }
+
+        [Test]
+        public void the_base_metric_prefix_should_be_used()
+        {
+            Assert.That(_combinedConfig.MetricPrefix, Is.EqualTo(_baseConfig.MetricPrefix));
+        }
+
+        [Test]
+        public void the_base_interval_should_be_used()
+        {
+            Assert.That(_combinedConfig.Interval, Is.EqualTo(_baseConfig.Interval));
+        }
+
+        [Test]
+        public void the_metrics_from_the_base_and_override_should_be_combined_together()
+        {
+            Assert.That(_combinedConfig.Metrics.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void any_base_metrics_should_be_in_the_combined_config()
+        {
+            Assert.That(_combinedConfig.Metrics.Any(m => m.Template.Equals("base.performance.counter")));
+        }
+    }
+}

--- a/spectator.Tests/Configuration/ConfigurationDifferenceSummaryTests.cs
+++ b/spectator.Tests/Configuration/ConfigurationDifferenceSummaryTests.cs
@@ -130,7 +130,7 @@ namespace spectator.Tests.Configuration
         [Test]
         public void when_given_two_configurations_with_differences_then_a_summary_is_created()
         {
-            var first = JsonSpectatorConfiguration.LoadFromString(@"{
+            var first = JsonSpectatorConfiguration.LoadConfigFromString(@"{
                       ""statsdHost"": ""basehost"",
                       ""statsdPort"": 8125,
                       ""metricPrefix"": ""base.prefix"",
@@ -145,7 +145,7 @@ namespace spectator.Tests.Configuration
                       ]
                     }");
 
-            var second = JsonSpectatorConfiguration.LoadFromString(@"{
+            var second = JsonSpectatorConfiguration.LoadConfigFromString(@"{
                       ""statsdHost"": ""overridehost"",
                       ""statsdPort"": 8126,
                       ""metricPrefix"": ""override.prefix"",

--- a/spectator.Tests/Configuration/JsonSpectatorConfigurationTests.cs
+++ b/spectator.Tests/Configuration/JsonSpectatorConfigurationTests.cs
@@ -10,7 +10,7 @@ namespace spectator.Tests.Configuration
         [Test]
         public void can_load_json_formatted_configuration()
         {
-            var config = JsonSpectatorConfiguration.LoadFromString(
+            var config = JsonSpectatorConfiguration.LoadConfigFromString(
                   @"{
                       ""statsdHost"": ""localhost"",
                       ""statsdPort"": 8125,

--- a/spectator.Tests/Some.cs
+++ b/spectator.Tests/Some.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace spectator.Tests
+﻿namespace spectator.Tests
 {
     public static class Some
     {

--- a/spectator.Tests/Sources/PerformanceCounterRegistryTestHarness.cs
+++ b/spectator.Tests/Sources/PerformanceCounterRegistryTestHarness.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using spectator.Sources;
 using spectator.Sources.PerformanceCounters;
 
 namespace spectator.Tests.Sources

--- a/spectator.Tests/Sources/QueryableSourceFactoryTests.cs
+++ b/spectator.Tests/Sources/QueryableSourceFactoryTests.cs
@@ -2,6 +2,7 @@
 using spectator.Configuration;
 using spectator.Sources;
 using spectator.Sources.PerformanceCounters;
+using spectator.Sources.WMI;
 
 namespace spectator.Tests.Sources
 {

--- a/spectator.Tests/Sources/WindowsManagementInstrumentationDefinitionTests.cs
+++ b/spectator.Tests/Sources/WindowsManagementInstrumentationDefinitionTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NUnit.Framework;
-using spectator.Sources;
 using spectator.Sources.WMI;
 
 namespace spectator.Tests.Sources

--- a/spectator.Tests/Sources/WindowsManagementInstrumentationDefinitionTests.cs
+++ b/spectator.Tests/Sources/WindowsManagementInstrumentationDefinitionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using spectator.Sources;
+using spectator.Sources.WMI;
 
 namespace spectator.Tests.Sources
 {

--- a/spectator.Tests/spectator.Tests.csproj
+++ b/spectator.Tests/spectator.Tests.csproj
@@ -50,7 +50,8 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Configuration\CombinedSpectatorConfigurationTests.cs" />
+    <Compile Include="Configuration\CombinedSpectatorConfigurationTests\WithEmptyOverridesTests.cs" />
+    <Compile Include="Configuration\CombinedSpectatorConfigurationTests\WithBasicOverridesTests.cs" />
     <Compile Include="Configuration\ConfigurationDifferenceSummaryTests.cs" />
     <Compile Include="Configuration\ConfigurationResolverTests.cs" />
     <Compile Include="Configuration\EmptyConfigurationTests.cs" />

--- a/spectator.sln
+++ b/spectator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spectator", "spectator\spectator.csproj", "{C3E2C24C-DABD-4A2E-ADC9-46685085EFA9}"
 EndProject
@@ -10,6 +10,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4BFAE616-6C83-48AE-83DE-69FDF3D8A558}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		build.cake = build.cake
+		build.cmd = build.cmd
+		build.ps1 = build.ps1
+		build.sh = build.sh
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/spectator/Configuration/CombinedSpectatorConfiguration.cs
+++ b/spectator/Configuration/CombinedSpectatorConfiguration.cs
@@ -8,18 +8,17 @@ namespace spectator.Configuration
     public class CombinedSpectatorConfiguration : ISpectatorConfiguration
     {
         private readonly ISpectatorConfiguration _baseConfiguration;
-        private readonly ISpectatorConfiguration _overrideConfiguration;
-        private readonly IList<MetricConfiguration> _combinedMetricConfigurations;
+        private readonly ISpectatorOverrideConfiguration _overrideConfiguration;
 
-        public string StatsdHost { get { return _overrideConfiguration.StatsdHost ?? _baseConfiguration.StatsdHost; } }
+        public string StatsdHost => _overrideConfiguration.StatsdHost ?? _baseConfiguration.StatsdHost;
 
-        public int StatsdPort { get { return _overrideConfiguration.StatsdPort; } }
+        public int StatsdPort => _overrideConfiguration.StatsdPort ?? _baseConfiguration.StatsdPort;
 
-        public string MetricPrefix { get { return _overrideConfiguration.MetricPrefix ?? _baseConfiguration.MetricPrefix; } }
+        public string MetricPrefix => _overrideConfiguration.MetricPrefix ?? _baseConfiguration.MetricPrefix;
 
-        public TimeSpan Interval { get { return _overrideConfiguration.Interval; } }
+        public TimeSpan Interval => _overrideConfiguration.Interval ?? _baseConfiguration.Interval;
 
-        public IList<MetricConfiguration> Metrics { get { return _combinedMetricConfigurations; } }
+        public IList<MetricConfiguration> Metrics { get; }
 
         private IList<MetricConfiguration> CombineMetricConfigurations(IList<MetricConfiguration> baseMetrics, IList<MetricConfiguration> overrideMetrics)
         {
@@ -52,12 +51,12 @@ namespace spectator.Configuration
             return combinedMetricConfiguration;
         }
 
-        public CombinedSpectatorConfiguration(ISpectatorConfiguration baseConfiguration, ISpectatorConfiguration overrideConfiguration)
+        public CombinedSpectatorConfiguration(ISpectatorConfiguration baseConfiguration, ISpectatorOverrideConfiguration overrideConfiguration)
         {
             _baseConfiguration = baseConfiguration;
             _overrideConfiguration = overrideConfiguration;
 
-            _combinedMetricConfigurations = CombineMetricConfigurations(_baseConfiguration.Metrics, _overrideConfiguration.Metrics);
+            Metrics = CombineMetricConfigurations(_baseConfiguration.Metrics, _overrideConfiguration.Metrics);
         }
     }
 }

--- a/spectator/Configuration/CombinedSpectatorConfiguration.cs
+++ b/spectator/Configuration/CombinedSpectatorConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using spectator.Configuration.Overrides;
 using spectator.Infrastructure;
 
 namespace spectator.Configuration

--- a/spectator/Configuration/CombinedSpectatorConfiguration.cs
+++ b/spectator/Configuration/CombinedSpectatorConfiguration.cs
@@ -20,7 +20,7 @@ namespace spectator.Configuration
 
         public IList<MetricConfiguration> Metrics { get; }
 
-        private IList<MetricConfiguration> CombineMetricConfigurations(IList<MetricConfiguration> baseMetrics, IList<MetricConfiguration> overrideMetrics)
+        private static IList<MetricConfiguration> CombineMetricConfigurations(IList<MetricConfiguration> baseMetrics, IList<MetricConfiguration> overrideMetrics)
         {
             if (overrideMetrics.IsNull() || !overrideMetrics.Any())
             {

--- a/spectator/Configuration/ConfigurationResolver.cs
+++ b/spectator/Configuration/ConfigurationResolver.cs
@@ -26,14 +26,9 @@ namespace spectator.Configuration
             var consulKey = ConfigurationManager.AppSettings[@"Spectator.ConsulKey"];
             var jsonConfigFile = ConfigurationManager.AppSettings[@"Spectator.JsonConfigFile"] ?? DefaultSpectatorConfigFile;
 
-            var baseJsonConfig = JsonSpectatorConfiguration.LoadFrom(BaseSpectatorConfigFile);
+            var baseJsonConfig = JsonSpectatorConfiguration.LoadConfigFrom(BaseSpectatorConfigFile);
             var overrideJsonConfig = Fallback.On(() => ConsulSpectatorConfiguration.LoadFrom(consulHost, consulKey, saveTo: jsonConfigFile),
-                                                 () => JsonSpectatorConfiguration.LoadFrom(jsonConfigFile));
-
-            if (baseJsonConfig is EmptyConfiguration)
-            {
-                return overrideJsonConfig;
-            }
+                                                 () => JsonSpectatorConfiguration.LoadOverrideFrom(jsonConfigFile));
 
             Log.InfoFormat("Using combined configuration using base config file '{0}' ({1} metrics) and overriding with loaded {2} metrics", BaseSpectatorConfigFile, baseJsonConfig.Metrics.Count, overrideJsonConfig.Metrics.Count);
 

--- a/spectator/Configuration/ConfigurationResolver.cs
+++ b/spectator/Configuration/ConfigurationResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Configuration;
 using log4net;
+using spectator.Configuration.Overrides;
 
 namespace spectator.Configuration
 {
@@ -27,7 +28,7 @@ namespace spectator.Configuration
             var jsonConfigFile = ConfigurationManager.AppSettings[@"Spectator.JsonConfigFile"] ?? DefaultSpectatorConfigFile;
 
             var baseJsonConfig = JsonSpectatorConfiguration.LoadConfigFrom(BaseSpectatorConfigFile);
-            var overrideJsonConfig = Fallback.On(() => ConsulSpectatorConfiguration.LoadFrom(consulHost, consulKey, saveTo: jsonConfigFile),
+            var overrideJsonConfig = Fallback.On(() => ConsulSpectatorOverrideConfiguration.LoadFrom(consulHost, consulKey, saveTo: jsonConfigFile),
                                                  () => JsonSpectatorConfiguration.LoadOverrideFrom(jsonConfigFile));
 
             Log.InfoFormat("Using combined configuration using base config file '{0}' ({1} metrics) and overriding with loaded {2} metrics", BaseSpectatorConfigFile, baseJsonConfig.Metrics.Count, overrideJsonConfig.Metrics.Count);

--- a/spectator/Configuration/ConsulSpectatorConfiguration.cs
+++ b/spectator/Configuration/ConsulSpectatorConfiguration.cs
@@ -7,7 +7,7 @@ using spectator.Infrastructure;
 
 namespace spectator.Configuration
 {
-    public class ConsulSpectatorConfiguration : ISpectatorConfiguration
+    public class ConsulSpectatorConfiguration : ISpectatorOverrideConfiguration
     {
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -23,18 +23,18 @@ namespace spectator.Configuration
 
             Log.InfoFormat("Using configuration read from consul host '{0}', in key '{1}'", host, key);
 
-            _innerConfiguration = JsonSpectatorConfiguration.LoadFromString(_configContents);
+            _innerConfiguration = JsonSpectatorConfiguration.LoadConfigFromString(_configContents);
         }
 
-        public string StatsdHost { get { return _innerConfiguration.StatsdHost; } }
+        public string StatsdHost => _innerConfiguration.StatsdHost;
 
-        public int StatsdPort { get { return _innerConfiguration.StatsdPort; } }
+        public int? StatsdPort => _innerConfiguration.StatsdPort;
 
-        public string MetricPrefix { get { return _innerConfiguration.MetricPrefix; } }
+        public string MetricPrefix => _innerConfiguration.MetricPrefix;
 
-        public TimeSpan Interval { get { return _innerConfiguration.Interval; } }
+        public TimeSpan? Interval => _innerConfiguration.Interval;
 
-        public IList<MetricConfiguration> Metrics { get { return _innerConfiguration.Metrics; } }
+        public IList<MetricConfiguration> Metrics => _innerConfiguration.Metrics;
 
         private void Save(string destinationPath)
         {
@@ -42,7 +42,7 @@ namespace spectator.Configuration
             fileAdapter.WriteAllText(destinationPath, _configContents);
         }
 
-        public static ISpectatorConfiguration LoadFrom(string host, string key, string saveTo)
+        public static ISpectatorOverrideConfiguration LoadFrom(string host, string key, string saveTo)
         {
             if (string.IsNullOrEmpty(host) && string.IsNullOrEmpty(key))
             {

--- a/spectator/Configuration/EmptyConfiguration.cs
+++ b/spectator/Configuration/EmptyConfiguration.cs
@@ -5,14 +5,14 @@ namespace spectator.Configuration
 {
     public class EmptyConfiguration : ISpectatorConfiguration
     {
-        public string StatsdHost { get { return string.Empty; } }
+        public string StatsdHost => string.Empty;
 
-        public int StatsdPort { get { return 0; } }
+        public int StatsdPort => 0;
 
-        public string MetricPrefix { get { return string.Empty; } }
+        public string MetricPrefix => string.Empty;
 
-        public TimeSpan Interval { get { return TimeSpan.FromSeconds(5); } }
+        public TimeSpan Interval => TimeSpan.FromSeconds(5);
 
-        public IList<MetricConfiguration> Metrics { get { return new List<MetricConfiguration>(); } }
+        public IList<MetricConfiguration> Metrics => new List<MetricConfiguration>();
     }
 }

--- a/spectator/Configuration/EmptyOverrideConfiguration.cs
+++ b/spectator/Configuration/EmptyOverrideConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace spectator.Configuration
+{
+    public class EmptyOverrideConfiguration : ISpectatorOverrideConfiguration
+    {
+        public string StatsdHost => null;
+
+        public int? StatsdPort => null;
+
+        public string MetricPrefix => null;
+
+        public TimeSpan? Interval => null;
+
+        public IList<MetricConfiguration> Metrics => new List<MetricConfiguration>();
+    }
+}

--- a/spectator/Configuration/EmptyOverrideConfiguration.cs
+++ b/spectator/Configuration/EmptyOverrideConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using spectator.Configuration.Overrides;
 
 namespace spectator.Configuration
 {

--- a/spectator/Configuration/ExpiringConfigurationDecorator.cs
+++ b/spectator/Configuration/ExpiringConfigurationDecorator.cs
@@ -35,29 +35,32 @@ namespace spectator.Configuration
         private T Get<T>(Func<ISpectatorConfiguration, T> configValue)
         {
             var now = DateTimeOffset.UtcNow;
-            if (now > _expiration)
+
+            if (now <= _expiration)
             {
-                Log.Info("Configuration has expired, refreshing from source");
-
-                var newConfig = _spectatorConfigurationFactory();
-
-                _expiration = now + _expirationInterval;
-
-                Log.Info("Configuration loaded.");
-
-                if (_configurationInstance != null)
-                {
-                    var diff = new ConfigurationDifferenceSummary(_configurationInstance, newConfig);
-
-                    if (!diff.IsEmpty())
-                    {
-                        Log.Info("Configuration changed: \n" + diff);
-                    }
-                }
-
-                _configurationInstance = newConfig;
-                Log.InfoFormat("Expires next at: {0}", _expiration.ToString("o"));
+                return configValue(_configurationInstance);
             }
+
+            Log.Info("Configuration has expired, refreshing from source");
+
+            var newConfig = _spectatorConfigurationFactory();
+
+            _expiration = now + _expirationInterval;
+
+            Log.Info("Configuration loaded.");
+
+            if (_configurationInstance != null)
+            {
+                var diff = new ConfigurationDifferenceSummary(_configurationInstance, newConfig);
+
+                if (!diff.IsEmpty())
+                {
+                    Log.Info("Configuration changed: \n" + diff);
+                }
+            }
+
+            _configurationInstance = newConfig;
+            Log.InfoFormat("Expires next at: {0}", _expiration.ToString("o"));
 
             return configValue(_configurationInstance);
         }

--- a/spectator/Configuration/Fallback.cs
+++ b/spectator/Configuration/Fallback.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using log4net;
+using spectator.Configuration.Overrides;
 
 namespace spectator.Configuration
 {

--- a/spectator/Configuration/Fallback.cs
+++ b/spectator/Configuration/Fallback.cs
@@ -20,5 +20,19 @@ namespace spectator.Configuration
                 return fallbackFactory();
             }
         }
+
+        public static ISpectatorOverrideConfiguration On(Func<ISpectatorOverrideConfiguration> configFactory, Func<ISpectatorOverrideConfiguration> fallbackFactory)
+        {
+            try
+            {
+                return configFactory();
+            }
+            catch (Exception ex)
+            {
+                Log.WarnFormat("Couldn't obtain primary configuration ('{0}'), falling back to secondary configuration", ex.Message);
+
+                return fallbackFactory();
+            }
+        }
     }
 }

--- a/spectator/Configuration/ISpectatorOverrideConfiguration.cs
+++ b/spectator/Configuration/ISpectatorOverrideConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace spectator.Configuration
+{
+    public interface ISpectatorOverrideConfiguration
+    {
+        string StatsdHost { get; }
+
+        int? StatsdPort { get; }
+
+        string MetricPrefix { get; }
+
+        TimeSpan? Interval { get; }
+
+        IList<MetricConfiguration> Metrics { get; }
+    }
+}

--- a/spectator/Configuration/JsonSpectatorConfiguration.cs
+++ b/spectator/Configuration/JsonSpectatorConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using spectator.Configuration.Overrides;
 using spectator.Infrastructure;
 
 namespace spectator.Configuration

--- a/spectator/Configuration/JsonSpectatorConfiguration.cs
+++ b/spectator/Configuration/JsonSpectatorConfiguration.cs
@@ -5,19 +5,23 @@ using spectator.Infrastructure;
 
 namespace spectator.Configuration
 {
-    public class JsonSpectatorConfiguration : ISpectatorConfiguration
+    public class JsonSpectatorConfiguration : ISpectatorOverrideConfiguration, ISpectatorConfiguration
     {
         public string StatsdHost { get; set; }
 
-        public int StatsdPort { get; set; }
+        int ISpectatorConfiguration.StatsdPort => StatsdPort ?? 0;
+
+        public int? StatsdPort { get; set; }
 
         public string MetricPrefix { get; set; }
 
-        public TimeSpan Interval { get; set; }
+        TimeSpan ISpectatorConfiguration.Interval => Interval ?? TimeSpan.Zero;
+
+        public TimeSpan? Interval { get; set; }
 
         public IList<MetricConfiguration> Metrics { get; set; }
 
-        public static ISpectatorConfiguration LoadFrom(string path)
+        public static ISpectatorConfiguration LoadConfigFrom(string path)
         {
             var fileAdapter = new FileAdapter();
 
@@ -25,7 +29,7 @@ namespace spectator.Configuration
             {
                 var configContents = fileAdapter.ReadAllText(path);
 
-                return LoadFromString(configContents);
+                return LoadConfigFromString(configContents);
             }
             catch
             {
@@ -33,9 +37,25 @@ namespace spectator.Configuration
             }
         }
 
-        public static ISpectatorConfiguration LoadFromString(string contents)
+        public static JsonSpectatorConfiguration LoadConfigFromString(string contents)
         {
             return JsonConvert.DeserializeObject<JsonSpectatorConfiguration>(contents);
+        }
+
+        public static ISpectatorOverrideConfiguration LoadOverrideFrom(string path)
+        {
+            var fileAdapter = new FileAdapter();
+
+            try
+            {
+                var configContents = fileAdapter.ReadAllText(path);
+
+                return LoadConfigFromString(configContents);
+            }
+            catch
+            {
+                return new EmptyOverrideConfiguration();
+            }
         }
     }
 }

--- a/spectator/Configuration/Overrides/ConsulSpectatorOverrideConfiguration.cs
+++ b/spectator/Configuration/Overrides/ConsulSpectatorOverrideConfiguration.cs
@@ -5,16 +5,16 @@ using Consul;
 using log4net;
 using spectator.Infrastructure;
 
-namespace spectator.Configuration
+namespace spectator.Configuration.Overrides
 {
-    public class ConsulSpectatorConfiguration : ISpectatorOverrideConfiguration
+    public class ConsulSpectatorOverrideConfiguration : ISpectatorOverrideConfiguration
     {
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private readonly ISpectatorConfiguration _innerConfiguration;
         private readonly string _configContents;
 
-        public ConsulSpectatorConfiguration(string host, string key)
+        public ConsulSpectatorOverrideConfiguration(string host, string key)
         {
             var client = string.IsNullOrEmpty(host) ? new Client() : new Client(new ConsulClientConfiguration { Address = host });
 
@@ -49,7 +49,7 @@ namespace spectator.Configuration
                 throw new ArgumentException("A consul host or key must be provided to use a consul configuration.");
             }
 
-            var config = new ConsulSpectatorConfiguration(host, key);
+            var config = new ConsulSpectatorOverrideConfiguration(host, key);
 
             config.Save(saveTo);
 

--- a/spectator/Configuration/Overrides/ISpectatorOverrideConfiguration.cs
+++ b/spectator/Configuration/Overrides/ISpectatorOverrideConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace spectator.Configuration
+namespace spectator.Configuration.Overrides
 {
     public interface ISpectatorOverrideConfiguration
     {

--- a/spectator/Infrastructure/Must.cs
+++ b/spectator/Infrastructure/Must.cs
@@ -9,14 +9,15 @@ namespace spectator.Infrastructure
         {
             var obj = objectExpression.Compile()();
 
-            if (obj == null)
+            if (obj != null)
             {
-                var memberExpression = objectExpression.Body as MemberExpression;
-                var objectName = memberExpression.Member.Name;
-
-                throw new ArgumentNullException(objectName);
+                return;
             }
-        }
 
+            var memberExpression = objectExpression.Body as MemberExpression;
+            var objectName = memberExpression.Member.Name;
+
+            throw new ArgumentNullException(objectName);
+        }
     }
 }

--- a/spectator/Metrics/MetricFormatter.cs
+++ b/spectator/Metrics/MetricFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using spectator.Infrastructure;
 
@@ -25,12 +26,7 @@ namespace spectator.Metrics
 
         private string FormatTemplatedValues(string formatted)
         {
-            foreach (var replacement in _registeredReplacements)
-            {
-                formatted = formatted.Replace("{" + replacement.Key + "}", replacement.Value.ToLowerInvariant());
-            }
-
-            return formatted;
+            return _registeredReplacements.Aggregate(formatted, (current, replacement) => current.Replace("{" + replacement.Key + "}", replacement.Value.ToLowerInvariant()));
         }
 
         private static string FormatInstanceName(string instance, string formatted)
@@ -45,7 +41,7 @@ namespace spectator.Metrics
 
         private string Sanitise(string formatted)
         {
-            char[] charArray = formatted.ToCharArray();
+            var charArray = formatted.ToCharArray();
 
             charArray = Array.FindAll(charArray, c => char.IsLetterOrDigit(c)
                                                    || c == '-'

--- a/spectator/Sources/QueryableSourceFactory.cs
+++ b/spectator/Sources/QueryableSourceFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using spectator.Configuration;
 using spectator.Sources.PerformanceCounters;
+using spectator.Sources.WMI;
 
 namespace spectator.Sources
 {

--- a/spectator/Sources/WMI/WindowsManagementInstrumentationDefinition.cs
+++ b/spectator/Sources/WMI/WindowsManagementInstrumentationDefinition.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using spectator.Infrastructure;
 
-namespace spectator.Sources
+namespace spectator.Sources.WMI
 {
     internal class WindowsManagementInstrumentationDefinition
     {

--- a/spectator/Sources/WMI/WindowsManagementInstrumentationSource.cs
+++ b/spectator/Sources/WMI/WindowsManagementInstrumentationSource.cs
@@ -12,8 +12,9 @@ namespace spectator.Sources.WMI
 
             using (var searcher = new ManagementObjectSearcher("select * from " + definition.QuerySource))
             {
-                foreach (ManagementObject managedObject in searcher.Get())
+                foreach (var foundObject in searcher.Get())
                 {
+                    var managedObject = (ManagementObject) foundObject;
                     var value = GetInfo(managedObject, definition.PropertyName);
 
                     managedObject.Dispose();
@@ -21,13 +22,13 @@ namespace spectator.Sources.WMI
                     return new[] {new Sample(string.Empty, value)};
                 }
 
-                throw new NotSupportedException(string.Format("Could not find property '{0}' on any managed object in query source '{1}'", definition.PropertyName, definition.QuerySource));
+                throw new NotSupportedException($"Could not find property '{definition.PropertyName}' on any managed object in query source '{definition.QuerySource}'");
             }
         }
 
-        private static double GetInfo(ManagementObject managedObject, string property)
+        private static double GetInfo(ManagementBaseObject managedObject, string property)
         {
-            object manageObjectProperty = managedObject[property];
+            var manageObjectProperty = managedObject[property];
 
             double value = (ulong)manageObjectProperty;
 

--- a/spectator/Sources/WMI/WindowsManagementInstrumentationSource.cs
+++ b/spectator/Sources/WMI/WindowsManagementInstrumentationSource.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Management;
 
-namespace spectator.Sources
+namespace spectator.Sources.WMI
 {
     public class WindowsManagementInstrumentationSource : IQueryableSource
     {

--- a/spectator/SpectatorService.cs
+++ b/spectator/SpectatorService.cs
@@ -71,16 +71,18 @@ namespace spectator
 
                     var metricValues = queryableSource.QueryValue(metric.Path).ToList();
 
-                    Log.DebugFormat("  -> Queried '{0}' from '{1}', resulting in {2} metric samples (unfiltered)", metric.Path, metric.Source, metricValues.Count());
+                    Log.DebugFormat("  -> Queried '{0}' from '{1}', resulting in {2} metric samples (unfiltered)", metric.Path, metric.Source, metricValues.Count);
 
                     foreach (var sample in metricValues)
                     {
-                        if (Included(metric.Include, sample.Instance) && !Excluded(metric.Exclude, sample.Instance))
+                        if (!Included(metric.Include, sample.Instance) || Excluded(metric.Exclude, sample.Instance))
                         {
-                            var metricName = _metricFormatter.Format(metricPrefix, sample.Instance, metric.Template);
-
-                            allMetrics.Add(new Metric(metricName, sample.Value, metric.Type));
+                            continue;
                         }
+
+                        var metricName = _metricFormatter.Format(metricPrefix, sample.Instance, metric.Template);
+
+                        allMetrics.Add(new Metric(metricName, sample.Value, metric.Type));
                     }
                 });
 
@@ -97,12 +99,12 @@ namespace spectator
             }
         }
 
-        private bool Included(string includePattern, string instance)
+        private static bool Included(string includePattern, string instance)
         {
             return string.IsNullOrEmpty(includePattern) || Regex.IsMatch(instance, includePattern);
         }
 
-        private bool Excluded(string excludePattern, string instance)
+        private static bool Excluded(string excludePattern, string instance)
         {
             return !string.IsNullOrEmpty(excludePattern) && Regex.IsMatch(instance, excludePattern);
         }

--- a/spectator/spectator.csproj
+++ b/spectator/spectator.csproj
@@ -69,9 +69,11 @@
     <Compile Include="Configuration\ConfigurationExtensions.cs" />
     <Compile Include="Configuration\ConfigurationResolver.cs" />
     <Compile Include="Configuration\ConsulSpectatorConfiguration.cs" />
+    <Compile Include="Configuration\EmptyOverrideConfiguration.cs" />
     <Compile Include="Configuration\EmptyConfiguration.cs" />
     <Compile Include="Configuration\ExpiringConfigurationDecorator.cs" />
     <Compile Include="Configuration\IConfigurationResolver.cs" />
+    <Compile Include="Configuration\ISpectatorOverrideConfiguration.cs" />
     <Compile Include="Configuration\ISpectatorConfiguration.cs" />
     <Compile Include="Configuration\JsonSpectatorConfiguration.cs" />
     <Compile Include="Configuration\MetricConfiguration.cs" />

--- a/spectator/spectator.csproj
+++ b/spectator/spectator.csproj
@@ -68,12 +68,12 @@
     <Compile Include="Configuration\ConfigurationDifferenceSummary.cs" />
     <Compile Include="Configuration\ConfigurationExtensions.cs" />
     <Compile Include="Configuration\ConfigurationResolver.cs" />
-    <Compile Include="Configuration\ConsulSpectatorConfiguration.cs" />
+    <Compile Include="Configuration\Overrides\ConsulSpectatorOverrideConfiguration.cs" />
     <Compile Include="Configuration\EmptyOverrideConfiguration.cs" />
     <Compile Include="Configuration\EmptyConfiguration.cs" />
     <Compile Include="Configuration\ExpiringConfigurationDecorator.cs" />
     <Compile Include="Configuration\IConfigurationResolver.cs" />
-    <Compile Include="Configuration\ISpectatorOverrideConfiguration.cs" />
+    <Compile Include="Configuration\Overrides\ISpectatorOverrideConfiguration.cs" />
     <Compile Include="Configuration\ISpectatorConfiguration.cs" />
     <Compile Include="Configuration\JsonSpectatorConfiguration.cs" />
     <Compile Include="Configuration\MetricConfiguration.cs" />
@@ -115,6 +115,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/spectator/spectator.csproj
+++ b/spectator/spectator.csproj
@@ -101,8 +101,8 @@
     <Compile Include="Sources\PerformanceCounters\PerformanceCounterSource.cs" />
     <Compile Include="Sources\QueryableSourceFactory.cs" />
     <Compile Include="Sources\Sample.cs" />
-    <Compile Include="Sources\WindowsManagementInstrumentationDefinition.cs" />
-    <Compile Include="Sources\WindowsManagementInstrumentationSource.cs" />
+    <Compile Include="Sources\WMI\WindowsManagementInstrumentationDefinition.cs" />
+    <Compile Include="Sources\WMI\WindowsManagementInstrumentationSource.cs" />
     <Compile Include="SpectatorService.cs" />
     <Compile Include="Metrics\StatsdPublisher.cs" />
   </ItemGroup>


### PR DESCRIPTION
Addressing issue #3 to allow override configurations (either in local files or stored in consul) to have nullable properties for host, port etc. So that they are not strictly required when creating overrides.